### PR TITLE
Fix for window not always closing

### DIFF
--- a/torchat/src/tc_gui.py
+++ b/torchat/src/tc_gui.py
@@ -524,6 +524,9 @@ class DlgEditContact(wx.Dialog):
     def onCancel(self,evt):
         self.Close()
 
+        #in some cases, self.Close will not work. This should fix that
+        evt.Skip()
+
 
 class DlgEditProfile(wx.Dialog):
     def __init__(self, parent, main_window):
@@ -671,6 +674,9 @@ class DlgEditProfile(wx.Dialog):
             tc_client.wipeFile(avatar_new)
 
         self.Close()
+
+        #in some cases, self.Close will not work. This should fix that
+        evt.Skip()
 
     def onOk(self, evt):
         config.set("profile", "name", self.txt_name.GetValue())


### PR DESCRIPTION
There is a bug where, for some people, self.Close in the onCancel function will not work. This will effectively make it so the window cannot be closed at all. Not with the cancel button, the ok button, or the x button on the window. However, like in the dlg_settings file, it uses evt.Skip() to close their windows and it works perfectly. Appending it after the self.Close() function seems to fix this bug. The onCancel function ties into all close functions so when someone hits ok or the x button, not just the cancel button, onCancel is called.